### PR TITLE
add jxl support via jxl-oxide

### DIFF
--- a/backend/core/Cargo.toml
+++ b/backend/core/Cargo.toml
@@ -26,3 +26,4 @@ tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+jxl-oxide = { version = "0.10.0", features = ["image"] }

--- a/backend/core/src/image.rs
+++ b/backend/core/src/image.rs
@@ -11,7 +11,9 @@ use blazebooru_common::util::{
 use blazebooru_models::local::HashedFile;
 use bytes::Bytes;
 use futures_core::Stream;
-use image::GenericImageView;
+use image::{DynamicImage, GenericImageView};
+use jxl_oxide::integration::JxlDecoder;
+use std::fs::File;
 
 use super::BlazeBooruCore;
 
@@ -104,10 +106,16 @@ impl BlazeBooruCore {
             ..
         }: &ProcessFileResult<'a>,
     ) -> Result<ProcessImageResult<'a>, anyhow::Error> {
-        // Open image file
-        let img = image::open(original_image_path)?;
-        let (width, height) = img.dimensions();
+        // Open image file with image-rs first, then try jxl-oxide if it fails
+        let img: DynamicImage = match image::open(original_image_path) {
+            Ok(image) => image,
+            Err(_) => {
+                let decoder = JxlDecoder::new(File::open(original_image_path).unwrap()).unwrap();
+                image::DynamicImage::from_decoder(decoder).unwrap()
+            }
+        };
 
+        let (width, height) = img.dimensions();
         // Generate thumbnail
         let tn_ext = "webp";
         let thumbnail_filename = format!("{hash}.{tn_ext}");


### PR DESCRIPTION
Adds jxl image support via jxl-oxide's image-rs integration support. while image-rs cannot encode jxl images, it can decode them so this winds up working fine.